### PR TITLE
Speed up cached compilation by avoiding tree rewriting if possible

### DIFF
--- a/ExpressionUtils/Evaluating/CachedExpressionCompiler.cs
+++ b/ExpressionUtils/Evaluating/CachedExpressionCompiler.cs
@@ -26,16 +26,23 @@ namespace MiaPlaza.ExpressionUtils.Evaluating {
 
 		VariadicArrayParametersDelegate IExpressionEvaluator.EvaluateLambda(LambdaExpression lambdaExpression) => CachedCompileLambda(lambdaExpression);
 		public VariadicArrayParametersDelegate CachedCompileLambda(LambdaExpression lambda) {
-			var extractionResult = ConstantExtractor.ExtractConstants(lambda.Body);
+			IReadOnlyList<object> constants;
 
-			var compiled = delegates.GetOrAdd(lambda, _ => ParameterListRewriter.RewriteLambda(
-				Expression.Lambda(
-					extractionResult.ConstantfreeExpression.Body, 
-					extractionResult.ConstantfreeExpression.Parameters.Concat(lambda.Parameters)))
-					.Compile()
-			);
+			if (delegates.TryGetValue(lambda, out var compiled)) {
+				constants = ConstantExtractor.ExtractConstantsOnly(lambda.Body);
+			} else {
+				var extractionResult = ConstantExtractor.ExtractConstants(lambda.Body);
 
-			return args => compiled(extractionResult.ExtractedConstants.Concat(args).ToArray());
+				compiled = ParameterListRewriter.RewriteLambda(
+					Expression.Lambda(
+						extractionResult.ConstantfreeExpression.Body,
+						extractionResult.ConstantfreeExpression.Parameters.Concat(lambda.Parameters)))
+					.Compile();
+				delegates.TryAdd(lambda, compiled);
+				constants = extractionResult.ExtractedConstants;
+			}
+
+			return args => compiled(constants.Concat(args).ToArray());
 		}
 
 		object IExpressionEvaluator.Evaluate(Expression unparametrizedExpression) => CachedCompile(unparametrizedExpression);

--- a/ExpressionUtilsPerf/ExpressionUtilsPerf.csproj
+++ b/ExpressionUtilsPerf/ExpressionUtilsPerf.csproj
@@ -102,12 +102,6 @@
       <Name>ExpressionUtils</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
-    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
-    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
-    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
-    <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.1.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
-  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.


### PR DESCRIPTION
During cached compilation, if we find the expression already compiled in the cache, we do not need a rewritten, constant-free expression anymore. Retrieving the constants only is sufficient and saves a lot of work for the `ExpressionVisitor`. Benchmarks show a 3-4x speedup.