### PR TITLE
Do not cache expression with references as constants

### DIFF
--- a/ExpressionUtils/CompiledActivator.cs
+++ b/ExpressionUtils/CompiledActivator.cs
@@ -61,5 +61,24 @@ namespace MiaPlaza.ExpressionUtils {
 				return constructor.Invoke();
 			}
 		}
+		
+		public static class ForAnyType {
+			private static ConcurrentDictionary<Type, Func<object>> cachedNew = new ConcurrentDictionary<Type, Func<object>>();
+
+			/// <summary>
+			/// Create a <paramref name="t"/> by invoking its default constructor.
+			/// This is much faster than <c>(T)Activator.CreateInstance(t)</c>.
+			/// </summary>
+			public static object Create(Type t) {
+				Func<object> constructor;
+				// We do not need to lock the dictionary; another thread can only overwrite it with the same value
+				if (!cachedNew.TryGetValue(t, out constructor)) {
+
+					constructor = Expression.Lambda<Func<object>>(Expression.TypeAs(Expression.New(t), typeof(object))).Compile();
+					cachedNew[t] = constructor;
+				}
+				return constructor.Invoke();
+			}
+		}
 	}
 }


### PR DESCRIPTION
When passing objects with hoisted variables we kept references to them
keeping vast amount of objects referenced that could have been and
should have been garbage collected.