### PR TITLE
Also target .Net Framework 4.7.1

### DIFF
--- a/ExpressionUtils/ExpressionUtils.csproj
+++ b/ExpressionUtils/ExpressionUtils.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>MiaPlaza.ExpressionUtils</RootNamespace>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net471</TargetFrameworks>
     <LangVersion>8</LangVersion>
     <AssemblyTitle>ExpressionUtils</AssemblyTitle>
     <Company>MiaPlaza</Company>
     <Product>MiaPlaza.ExpressionUtils.Properties</Product>
     <Description>Efficient Processing, Compilation, and Execution of Expression Trees at Runtime</Description>
     <Copyright>Copyright ©2017-2019 Miaplaza Inc.</Copyright>
-    <Version>1.1.6</Version>
-    <AssemblyVersion>1.1.6</AssemblyVersion>
-    <FileVersion>1.1.6</FileVersion>
+    <Version>1.1.7</Version>
+    <AssemblyVersion>1.1.7</AssemblyVersion>
+    <FileVersion>1.1.7</FileVersion>
     <ErrorReport>none</ErrorReport>
     <Authors>Miaplaza Inc.</Authors>
     <RepositoryUrl>https://github.com/Miaplaza/expression-utils</RepositoryUrl>
@@ -22,5 +22,9 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.6.0" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>


### PR DESCRIPTION
We need this internally to be able to still use the CSharpCompiler with
.NETFramework. We cannot compile and include a reference to a netstandard assembly.

The nuget package `Microsoft.NETFramework.ReferenceAssemblies` makes it
possible to target .NETFramework with `dotnet build` on linux and maxOS.