### PR TITLE
Fix expression caching

### DIFF
--- a/ExpressionUtils/CompiledActivator.cs
+++ b/ExpressionUtils/CompiledActivator.cs
@@ -61,24 +61,5 @@ namespace MiaPlaza.ExpressionUtils {
 				return constructor.Invoke();
 			}
 		}
-		
-		public static class ForAnyType {
-			private static ConcurrentDictionary<Type, Func<object>> cachedNew = new ConcurrentDictionary<Type, Func<object>>();
-
-			/// <summary>
-			/// Create a <paramref name="t"/> by invoking its default constructor.
-			/// This is much faster than <c>(T)Activator.CreateInstance(t)</c>.
-			/// </summary>
-			public static object Create(Type t) {
-				Func<object> constructor;
-				// We do not need to lock the dictionary; another thread can only overwrite it with the same value
-				if (!cachedNew.TryGetValue(t, out constructor)) {
-
-					constructor = Expression.Lambda<Func<object>>(Expression.TypeAs(Expression.New(t), typeof(object))).Compile();
-					cachedNew[t] = constructor;
-				}
-				return constructor.Invoke();
-			}
-		}
 	}
 }

--- a/ExpressionUtils/Evaluating/CachedExpressionCompiler.cs
+++ b/ExpressionUtils/Evaluating/CachedExpressionCompiler.cs
@@ -65,12 +65,12 @@ namespace MiaPlaza.ExpressionUtils.Evaluating {
 		private LambdaExpression getClosureFreeKeyForCaching(ConstantExtractor.ExtractionResult extractionResult, IReadOnlyCollection<ParameterExpression> parameterExpressions) {
 			var e = SimpleParameterSubstituter.SubstituteParameter(extractionResult.ConstantfreeExpression,
 				extractionResult.ConstantfreeExpression.Parameters.Select(
-						p => (Expression) Expression.Constant(GetDefaultValue(p.Type), p.Type)));
+						p => (Expression) Expression.Constant(getDefaultValue(p.Type), p.Type)));
 						
 			return Expression.Lambda(e, parameterExpressions);
 		}
 
-		private object GetDefaultValue(Type t) {
+		private static object getDefaultValue(Type t) {
 			if (t.IsValueType) {
 				return Activator.CreateInstance(t);
 			}

--- a/ExpressionUtils/ExpressionStructureIdentity.cs
+++ b/ExpressionUtils/ExpressionStructureIdentity.cs
@@ -237,7 +237,7 @@ namespace MiaPlaza.ExpressionUtils {
 
 			public int GetHashCode(Expression tree) => GetNodeTypeStructureHashCode(tree, IgnoreConstantsValues, HashCodeExpressionDepth);
 
-			bool IEqualityComparer<Expression>.Equals(Expression x, Expression y) => StructuralIdentical(x, y);
+			bool IEqualityComparer<Expression>.Equals(Expression x, Expression y) => StructuralIdentical(x, y, IgnoreConstantsValues);
 		}
 
 		/// <summary>

--- a/ExpressionUtils/ExpressionUtils.csproj
+++ b/ExpressionUtils/ExpressionUtils.csproj
@@ -8,9 +8,9 @@
     <Product>MiaPlaza.ExpressionUtils.Properties</Product>
     <Description>Efficient Processing, Compilation, and Execution of Expression Trees at Runtime</Description>
     <Copyright>Copyright ©2017-2019 Miaplaza Inc.</Copyright>
-    <Version>1.1.7</Version>
-    <AssemblyVersion>1.1.7</AssemblyVersion>
-    <FileVersion>1.1.7</FileVersion>
+    <Version>1.2.0</Version>
+    <AssemblyVersion>1.2.0</AssemblyVersion>
+    <FileVersion>1.2.0</FileVersion>
     <ErrorReport>none</ErrorReport>
     <Authors>Miaplaza Inc.</Authors>
     <RepositoryUrl>https://github.com/Miaplaza/expression-utils</RepositoryUrl>

--- a/ExpressionUtils/ParameterSubstituter.cs
+++ b/ExpressionUtils/ParameterSubstituter.cs
@@ -21,14 +21,15 @@ namespace MiaPlaza.ExpressionUtils {
 	/// To that end, the visitor also removes unecessary casts to find the most specific override
 	/// possible (<see cref="VisitUnary"/>.)
 	/// </remarks>
-	public class ParameterSubstituter : ExpressionVisitor {
-		public static Expression SubstituteParameter(LambdaExpression expression, params Expression[] replacements)
+	public class ParameterSubstituter : SimpleParameterSubstituter {
+
+		public static new Expression SubstituteParameter(LambdaExpression expression, params Expression[] replacements)
 			=> SubstituteParameter(expression, replacements as IReadOnlyCollection<Expression>);
 
-		public static Expression SubstituteParameter(LambdaExpression expression, IEnumerable<Expression> replacements)
+		public static new Expression SubstituteParameter(LambdaExpression expression, IEnumerable<Expression> replacements)
 			=> SubstituteParameter(expression, replacements.ToList());
 
-		public static Expression SubstituteParameter(LambdaExpression expression, IReadOnlyCollection<Expression> replacements) {
+		public static new Expression SubstituteParameter(LambdaExpression expression, IReadOnlyCollection<Expression> replacements) {
 			if (expression == null) {
 				throw new ArgumentNullException(nameof(expression));
 			}
@@ -56,20 +57,7 @@ namespace MiaPlaza.ExpressionUtils {
 		public static Expression SubstituteParameter(Expression expression, IReadOnlyDictionary<ParameterExpression, Expression> replacements)
 			=> new ParameterSubstituter(replacements).Visit(expression);
 
-		readonly IReadOnlyDictionary<ParameterExpression, Expression> replacements;
-
-		ParameterSubstituter(IReadOnlyDictionary<ParameterExpression, Expression> replacements) {
-			this.replacements = replacements;
-		}
-
-		protected override Expression VisitParameter(ParameterExpression node) {
-			Expression replacement;
-			if (replacements.TryGetValue(node, out replacement)) {
-				return replacement;
-			} else {
-				return node;
-			}
-		}
+		ParameterSubstituter(IReadOnlyDictionary<ParameterExpression, Expression> replacements) : base(replacements) {	}
 
 		protected override Expression VisitMember(MemberExpression node) {
 			var baseCallResult = (MemberExpression)base.VisitMember(node);
@@ -117,6 +105,10 @@ namespace MiaPlaza.ExpressionUtils {
 				}
 			}
 			return base.VisitUnary(node);
+		}
+
+		protected override Expression VisitBinary(BinaryExpression node) {
+			return base.VisitBinary(node);
 		}
 
 		private static MethodInfo getImplementationToCallOn(Type t, MethodInfo method) {

--- a/ExpressionUtils/SimpleParameterSubstituter.cs
+++ b/ExpressionUtils/SimpleParameterSubstituter.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace MiaPlaza.ExpressionUtils {
+	/// <summary>
+	/// Replaces all parameters in an lambda-expression by other expressions, i.e., given a lambda
+	/// <c>(t0, …, tn) → f(t0,…,tn)</c> and expressions <c>(x0,…,xn)</c>, it returns the expression <c>f(x0,…,xn)</c>.
+	/// </summary>
+	/// <remarks>
+	/// Does nothing else than that, esepicially does not change the structure of the expression or removes closures.false
+	/// If you want that and other optimizations, use see <cref="ParameterSubstituter" />
+	/// </remarks>
+	public class SimpleParameterSubstituter : ExpressionVisitor {
+		public static Expression SubstituteParameter(LambdaExpression expression, params Expression[] replacements)
+			=> SubstituteParameter(expression, replacements as IReadOnlyCollection<Expression>);
+
+		public static Expression SubstituteParameter(LambdaExpression expression, IEnumerable<Expression> replacements)
+			=> SubstituteParameter(expression, replacements.ToList());
+
+		public static Expression SubstituteParameter(LambdaExpression expression, IReadOnlyCollection<Expression> replacements) {
+			if (expression == null) {
+				throw new ArgumentNullException(nameof(expression));
+			}
+
+			if (replacements == null) {
+				throw new ArgumentNullException(nameof(replacements));
+			}
+
+			if (expression.Parameters.Count != replacements.Count) {
+				throw new ArgumentException($"Replacement count does not match parameter count ({replacements.Count} vs {expression.Parameters.Count})");
+			}
+
+			var dict = new Dictionary<ParameterExpression, Expression>();
+
+			foreach (var tuple in expression.Parameters.Zip(replacements, (p, r) => new { parameter = p, replacement = r })) {
+				if (!tuple.parameter.Type.IsAssignableFrom(tuple.replacement.Type)) {
+					throw new ArgumentException($"The expression {tuple.replacement} cannot be used as replacement for the parameter {tuple.parameter}.");
+				}
+				dict[tuple.parameter] = tuple.replacement;
+			}
+
+			return new SimpleParameterSubstituter(dict).Visit(expression.Body);
+		}
+
+		public static Expression SubstituteParameter(Expression expression, IReadOnlyDictionary<ParameterExpression, Expression> replacements)
+			=> new SimpleParameterSubstituter(replacements).Visit(expression);
+
+		readonly IReadOnlyDictionary<ParameterExpression, Expression> replacements;
+
+		protected SimpleParameterSubstituter(IReadOnlyDictionary<ParameterExpression, Expression> replacements) {
+			this.replacements = replacements;
+		}
+
+		protected override Expression VisitParameter(ParameterExpression node) {
+			Expression replacement;
+			if (replacements.TryGetValue(node, out replacement)) {
+				return replacement;
+			} else {
+				return node;
+			}
+		}
+	}
+}

--- a/ExpressionUtilsTest/CachedExpressionCompilerTestEvaluator.cs
+++ b/ExpressionUtilsTest/CachedExpressionCompilerTestEvaluator.cs
@@ -1,0 +1,26 @@
+using System.Linq.Expressions;
+using MiaPlaza.ExpressionUtils;
+using MiaPlaza.ExpressionUtils.Evaluating;
+using NUnit.Framework;
+
+namespace MiaPlaza.Test.ExpressionUtilsTest {
+	public class CachedExpressionCompilerTestEvaluator : IExpressionEvaluator {
+
+		public object Evaluate(Expression unparametrizedExpression) {
+			var lambda = Expression.Lambda(unparametrizedExpression);
+			return this.EvaluateLambda(lambda)();
+		}
+
+		public VariadicArrayParametersDelegate EvaluateLambda(LambdaExpression lambdaExpression) {
+			var result = ((IExpressionEvaluator)CachedExpressionCompiler.Instance).EvaluateLambda(lambdaExpression);
+			Assert.IsTrue(CachedExpressionCompiler.Instance.IsCached(lambdaExpression));
+			return result;
+		}
+
+		public DELEGATE EvaluateTypedLambda<DELEGATE>(Expression<DELEGATE> expression) where DELEGATE : class {
+
+			var result = this.EvaluateLambda(expression);
+			return result.WrapDelegate<DELEGATE>();
+		}
+	}
+}

--- a/ExpressionUtilsTest/ExpressionEvaluation.cs
+++ b/ExpressionUtilsTest/ExpressionEvaluation.cs
@@ -19,6 +19,7 @@ namespace MiaPlaza.Test.ExpressionUtilsTest {
 			new TestFixtureData(ExpressionCompiler.Instance),
 			new TestFixtureData(CachedExpressionCompiler.Instance),
 			new TestFixtureData(ExpressionInterpreter.Instance),
+			new TestFixtureData(new CachedExpressionCompilerTestEvaluator()),
 		};
 
 		private readonly IExpressionEvaluator evaluator;
@@ -119,6 +120,14 @@ namespace MiaPlaza.Test.ExpressionUtilsTest {
 			Assert.Catch(() => evaluator.Evaluate(expression.Body));
 		}
 
+		[Test]
+		public void TestNullableEnumExpression() {
+			Expression<Func<MyEnum?, bool>> expA = (MyEnum? t) => t == MyEnum.First;
+
+			Assert.IsTrue((bool)evaluator.EvaluateLambda(expA)(MyEnum.First));
+			Assert.IsFalse((bool)evaluator.EvaluateLambda(expA)(MyEnum.Second));
+		}
+
 		public static readonly IEnumerable<int> TestOffsets = new[] {
 			1,
 			100,
@@ -205,6 +214,16 @@ namespace MiaPlaza.Test.ExpressionUtilsTest {
 			Expression<Func<DateTime?, bool>> hasValue = date => date != null;
 			Assert.That((bool)evaluator.EvaluateLambda(hasValue)(DateTime.Now));
 			Assert.IsFalse((bool)(evaluator.EvaluateLambda(hasValue)((DateTime?)null)));
+		}
+
+		class ParentClass {}
+		class ChildClass : ParentClass {}  
+
+		[Test]
+		public void TestConvertExpresssion() {
+			var exp = Expression.Convert(Expression.Constant(new ChildClass()), typeof(ParentClass));
+
+			evaluator.Evaluate(exp);
 		}
 	}
 }

--- a/ExpressionUtilsTest/StructuralIdentity.cs
+++ b/ExpressionUtilsTest/StructuralIdentity.cs
@@ -188,5 +188,14 @@ namespace MiaPlaza.Test.ExpressionUtilsTest {
 
 			Assert.IsTrue(expA.StructuralIdentical(expB));
 		}
+
+		[Test]
+		public void TestClosureLambda() {
+			int variable = 7;
+			Expression<Func<int, bool>> expA = (int a) => a != variable;
+			Expression<Func<int, bool>> expB = (int a) => a != 8;
+
+			Assert.IsFalse(expA.StructuralIdentical(expB, true));
+		}		
 	}
 }


### PR DESCRIPTION
In this PR I (hopefully) and finally fix the expression compilation cache that has never fully worked before. Fixes are:

* Fix bug where IgnoreConstantsValues in StructuralComparer is ignored 
* Use a much simpler parameter substituter to
not change the structure of the expression when building the cache key
* Simplify default expression constant instantiation when building the
cache key
* Add test for structural identity
* Introduce CachedExpressionCompilerTestEvaluator to test if expression
that were evaluated with the CachedExpressionCompiler are cached
