### PR TITLE
Change hash code visitor, so that different hash codes are generated for different type check expressions

### DIFF
--- a/ExpressionUtils/ExpressionStructureIdentity.cs
+++ b/ExpressionUtils/ExpressionStructureIdentity.cs
@@ -76,7 +76,13 @@ namespace MiaPlaza.ExpressionUtils {
 				Hashing.Hash(ref ResultHash, node.Method.GetHashCode());
 				return base.VisitMethodCall(node);
 			}
-		}
+
+            protected override Expression VisitTypeBinary(TypeBinaryExpression node)
+            {
+                Hashing.Hash(ref ResultHash, node.TypeOperand.GetHashCode());
+                return base.VisitTypeBinary(node);
+            }
+        }
 
 		/// <summary>
 		/// A visitor that compares two expressions with each other.

--- a/ExpressionUtils/ExpressionUtils.csproj
+++ b/ExpressionUtils/ExpressionUtils.csproj
@@ -8,9 +8,9 @@
     <Product>MiaPlaza.ExpressionUtils.Properties</Product>
     <Description>Efficient Processing, Compilation, and Execution of Expression Trees at Runtime</Description>
     <Copyright>Copyright ©2017-2019 Miaplaza Inc.</Copyright>
-    <Version>1.2.0</Version>
-    <AssemblyVersion>1.2.0</AssemblyVersion>
-    <FileVersion>1.2.0</FileVersion>
+    <Version>1.2.1</Version>
+    <AssemblyVersion>1.2.1</AssemblyVersion>
+    <FileVersion>1.2.1</FileVersion>
     <ErrorReport>none</ErrorReport>
     <Authors>Miaplaza Inc.</Authors>
     <RepositoryUrl>https://github.com/Miaplaza/expression-utils</RepositoryUrl>


### PR DESCRIPTION
Currently if such expressions would produce the same hash code:
```csharp
(param) => param is ClassOne;
(param) => param is ClassTwo;
```

To fix this we will override  `VisitTypeBinary()` method to take into account hash code of type for which we check the param.