### PR TITLE
Fix incorrect removal of boxing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - run: dotnet restore ExpressionUtils.sln
+      - run: dotnet build ExpressionUtils.sln --configuration Release --no-restore
+      - run: dotnet test ExpressionUtilsTest/ExpressionUtilsTest.csproj --configuration Release --no-build --verbosity normal

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
           dotnet-version: 8.0.x
       - run: dotnet restore ExpressionUtils.sln
       - run: dotnet build ExpressionUtils.sln --configuration Release --no-restore
-      - run: dotnet test ExpressionUtilsTest/ExpressionUtilsTest.csproj --configuration Release --no-build --verbosity normal
+      - run: dotnet test ExpressionUtilsTest/ExpressionUtilsTest.csproj --configuration Debug --no-build --verbosity normal
       - run: dotnet pack ExpressionUtils/ExpressionUtils.csproj --configuration Release --no-build --output ./artifacts
       - uses: NuGet/login@v1
         id: login

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Publish
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - run: dotnet restore ExpressionUtils.sln
+      - run: dotnet build ExpressionUtils.sln --configuration Release --no-restore
+      - run: dotnet test ExpressionUtilsTest/ExpressionUtilsTest.csproj --configuration Release --no-build --verbosity normal
+      - run: dotnet pack ExpressionUtils/ExpressionUtils.csproj --configuration Release --no-build --output ./artifacts
+      - uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ vars.NUGET_USER }}
+      - run: dotnet nuget push './artifacts/*.nupkg' --api-key '${{ steps.login.outputs.NUGET_API_KEY }}' --source https://api.nuget.org/v3/index.json --skip-duplicate

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Test
 
 on:
   push:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,4 +14,4 @@ jobs:
           dotnet-version: 8.0.x
       - run: dotnet restore ExpressionUtils.sln
       - run: dotnet build ExpressionUtils.sln --configuration Release --no-restore
-      - run: dotnet test ExpressionUtilsTest/ExpressionUtilsTest.csproj --configuration Release --no-build --verbosity normal
+      - run: dotnet test ExpressionUtilsTest/ExpressionUtilsTest.csproj --configuration Debug --no-build --verbosity normal

--- a/ExpressionUtils/ParameterSubstituter.cs
+++ b/ExpressionUtils/ParameterSubstituter.cs
@@ -100,7 +100,9 @@ namespace MiaPlaza.ExpressionUtils {
 				var operand = this.Visit(node.Operand);
 				if (node.Type.IsAssignableFrom(operand.Type)
 					// a cast is lifted if it casts to a Nullable<>
-					&& !node.IsLifted) {
+					&& !node.IsLifted
+					// if this changes a value type to a reference type, then this is a boxing or unboxing which we must not strip
+					&& node.Operand.Type.IsValueType == node.Type.IsValueType) {
 					return operand;
 				} else {
 					return Expression.Convert(operand, node.Type);

--- a/ExpressionUtilsTest/ExpressionUtilsTest.csproj
+++ b/ExpressionUtilsTest/ExpressionUtilsTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>MiaPlaza.Test.ExpressionUtilsTest</RootNamespace>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
     <DebugType>full</DebugType>

--- a/ExpressionUtilsTest/ParameterSubstituter.cs
+++ b/ExpressionUtilsTest/ParameterSubstituter.cs
@@ -136,6 +136,8 @@ namespace MiaPlaza.Test.ExpressionUtilsTest {
 
 		private static readonly Expression<Func<int, string, bool>> simpleExpression = (i, s) => i.ToString() == s;
 		private static readonly Expression<Func<bool>> parameterlessExpression = () => true;
+		private static readonly Expression<Func<AttributeTargets, bool>> boxingExpression = (AttributeTargets t) => t.HasFlag(AttributeTargets.Assembly);
+		private static readonly Expression<Func<object, int>> unboxingExpression = (object o) => ((int)o) + 1;
 		private static readonly Expression<Func<IInterface, bool>> interfacePropertyExpression = i => i.Property;
 		private static readonly Expression<Func<IInterface, bool>> interfacePropertyCastExpression = i => ((IInterface)i).Property;
 		private static readonly Expression<Func<IInterface, string>> interfaceMethodExpression = i => i.Method(42);
@@ -172,12 +174,19 @@ namespace MiaPlaza.Test.ExpressionUtilsTest {
 			Assert.Throws<ArgumentException>(() =>
 				ExpressionUtils.ParameterSubstituter.SubstituteParameter(simpleExpression,
 					Expression.Constant(5), Expression.Constant("42"), Expression.Constant(true)));
+			Assert.Throws<ArgumentException>(() =>
+				ExpressionUtils.ParameterSubstituter.SubstituteParameter(boxingExpression,
+					Expression.Constant("Assembly")));
 		}
 
 		[Test]
 		public void TestDoesNotThrowOnValidArguments() {
 			ExpressionUtils.ParameterSubstituter.SubstituteParameter(simpleExpression,
 					Expression.Constant(5), Expression.Constant("42"));
+			ExpressionUtils.ParameterSubstituter.SubstituteParameter(boxingExpression,
+					Expression.Constant(AttributeTargets.All));
+			ExpressionUtils.ParameterSubstituter.SubstituteParameter(unboxingExpression,
+					Expression.Constant((object)42));
 		}
 
 		[Test]

--- a/README.md
+++ b/README.md
@@ -79,7 +79,4 @@ To create a new Release:
 
 * bump the version numbers in the project file
 * create a Release here on github
-* `dotnet pack -c Release`
-* `cd ExpressionUtils/bin/Release/`
-* Create an API key for **miaplaza** at https://www.nuget.org/account/apikeys
-* `dotnet nuget push MiaPlaza.ExpressionUtils.….nupgk -k YOUR_KEY_HERE -s -s https://api.nuget.org/v3/index.json`
+* the `publish` GitHub Actions workflow will build, test, pack, and publish to nuget.org


### PR DESCRIPTION
without this change HasFlag() would throw a DynamicEvaluationException because a value type, such as AttributeTargets, cannot be used as a boxed Enum (without explicit boxing.)