### PR TITLE
Use a modern framework to run tests

### DIFF
--- a/ExpressionUtilsTest/ExpressionUtilsTest.csproj
+++ b/ExpressionUtilsTest/ExpressionUtilsTest.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <RootNamespace>MiaPlaza.Test.ExpressionUtilsTest</RootNamespace>
-    <TargetFrameworks>netcoreapp3.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
     <DebugType>full</DebugType>


### PR DESCRIPTION
but keep the old framework for the actual library. We don't need any support for newer framework and this gives us the best compatibility, e.g., when building code generators.

Fixes #36 